### PR TITLE
Simplify AWK make: simplify slist, use mtimes directly

### DIFF
--- a/awkmake.awk
+++ b/awkmake.awk
@@ -2,16 +2,16 @@ BEGIN {
     while (getline <"makefile" > 0)
         if ($0 ~ /^[A-Za-z]/) {  #  $1: $2 $3 ...
             sub(/:/, "")
-            if (++names[nm = $1] > 1)
+            if (slist[nm = $1])
                 error(nm " is multiply defined")
-            for (i = 2; i <= NF; i++) # remember targets
-                slist[nm, ++scnt[nm]] = $i
+            sub(/^\S+\s*/, "")        # remove first field
+            slist[nm] = $0            # remember targets
         } else if ($0 ~ /^\t/)        # remember cmd for
             cmd[nm] = cmd[nm] $0 "\n" #   current name
         else if (NF > 0)
             error("illegal line in makefile: " $0)
     ages()      # compute initial ages
-    if (ARGV[1] in names) {
+    if (ARGV[1] in slist) {
         if (update(ARGV[1]) == 0)
             print ARGV[1] " is up to date"
     } else
@@ -22,23 +22,24 @@ function ages(      f,n,t) {
     for (t = 1; ("ls -t" | getline f) > 0; t++)
         age[f] = t   # all existing files get an age
     close("ls -t")
-    for (n in names)
+    for (n in slist)
         if (!(n in age))   # if n has not been created
             age[n] = 9999  # make n really old
 }
-function update(n,   changed,i,s) {
+function update(n,   changed,i,s,ndeps,deps) {
     if (!(n in age)) error(n " does not exist")
-    if (!(n in names)) return 0
+    if (!(n in slist)) return 0
     changed = 0
     visited[n] = 1
-    for (i = 1; i <= scnt[n]; i++) {
-        if (visited[s = slist[n, i]] == 0) update(s)
+    ndeps = split(slist[n], deps)
+    for (i = 1; i <= ndeps; i++) {
+        if (visited[s = deps[i]] == 0) update(s)
         else if (visited[s] == 1)
             error(s " and " n " are circularly defined")
         if (age[s] <= age[n]) changed++
     }
     visited[n] = 2
-    if (changed || scnt[n] == 0) {
+    if (changed || slist[n] == "") {
         printf("%s", cmd[n])
         system(cmd[n])  # execute cmd associated with n
         ages()          # recompute all ages

--- a/awkmake.awk
+++ b/awkmake.awk
@@ -10,7 +10,6 @@ BEGIN {
             cmd[nm] = cmd[nm] $0 "\n" #   current name
         else if (NF > 0)
             error("illegal line in makefile: " $0)
-    ages()      # compute initial ages
     if (ARGV[1] in slist) {
         if (update(ARGV[1]) == 0)
             print ARGV[1] " is up to date"
@@ -18,16 +17,15 @@ BEGIN {
         error(ARGV[1] " is not in makefile")
 }
 
-function ages(      f,n,t) {
-    for (t = 1; ("ls -t" | getline f) > 0; t++)
-        age[f] = t   # all existing files get an age
-    close("ls -t")
-    for (n in slist)
-        if (!(n in age))   # if n has not been created
-            age[n] = 9999  # make n really old
+function mtime(f,      cmd,t,ret) {
+    cmd = "TZ=UTC stat --format %y " f " 2>/dev/null"
+    cmd | getline t
+    close(cmd)
+    return t  # will be "" if f doesn't exist
 }
-function update(n,   changed,i,s,ndeps,deps) {
-    if (!(n in age)) error(n " does not exist")
+function update(n,   changed,i,s,ndeps,deps,ntime) {
+    ntime = mtime(n)
+    if (!(n in slist) && ntime == "") error(n " does not exist")
     if (!(n in slist)) return 0
     changed = 0
     visited[n] = 1
@@ -36,14 +34,12 @@ function update(n,   changed,i,s,ndeps,deps) {
         if (visited[s = deps[i]] == 0) update(s)
         else if (visited[s] == 1)
             error(s " and " n " are circularly defined")
-        if (age[s] <= age[n]) changed++
+        if (mtime(s) > ntime) changed++
     }
     visited[n] = 2
     if (changed || slist[n] == "") {
         printf("%s", cmd[n])
         system(cmd[n])  # execute cmd associated with n
-        ages()          # recompute all ages
-        age[n] = 0      # make n very new
         return 1
     }
     return 0


### PR DESCRIPTION
This branch is not intended to be merged, but to show the two simplifications to the original AWK version.